### PR TITLE
Update cloud panel API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ loadbalancer_id, loadbalancer, err := api.CreateLoadBalancer(&request)
 Optional parameters are `HealthCheckPath`, `HealthCheckPathParser`, `Source` and `Description`. Load balancer `Method` must be set to `"ROUND_ROBIN"` or `"LEAST_CONNECTIONS"`.
 
 **Update a load balancer:**
+
 ```
 request := oneandone.LoadBalancerRequest {
     Name: new_name,

--- a/setup.go
+++ b/setup.go
@@ -1,7 +1,7 @@
 package oneandone
 
 // The base url for 1&1 Cloud Server REST API.
-var BaseUrl = "https://cloudpanel-api.1and1.com/v1"
+var BaseUrl = "https://cloudpanel-api.ionos.com/v1"
 
 // Authentication token
 var Token string


### PR DESCRIPTION
From: https://github.com/1and1/oneandone-cloudserver-sdk-go/pull/37

We can't "clone" the PR from a repo, so I create this PR but credits to [thefirstspine](https://github.com/thefirstspine)